### PR TITLE
 Unescape the obtained text

### DIFF
--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,3 +1,4 @@
+import { unescape } from 'he';
 import { xml2json } from 'xml-js';
 
 interface TranscriptObject {
@@ -13,7 +14,7 @@ export function transcriptParser(input: string): TranscriptObject[] {
 
   return textArray.map((textData: any) => ({
     // Use the regular expression /\n/g and /\t/g to replace \n and \t with the empty string ''
-    text: textData._text.replace(/\n/g, '').replace(/\t/g, ''),
+    text: unescape(textData._text.replace(/\n/g, '').replace(/\t/g, '')),
     // If the start or dur is null or undefined use 0.0 as the default value
     start: parseFloat(textData._attributes.start) || 0.0,
     dur: parseFloat(textData._attributes.dur) || 0.0,


### PR DESCRIPTION
### Description
After the transcripts are obtained, the content of the text is not transcoded.The text needs to be unescaped to convert all HTML entity encodings to their original character forms.

### Changes
- Escape the content to be inserted into the text field