### PR TITLE
Fix the bug when there is no text field And Modify the format of manualCreatedTranscriptsContents

### DIFF
--- a/.changeset/slimy-beds-lie.md
+++ b/.changeset/slimy-beds-lie.md
@@ -1,0 +1,5 @@
+---
+"tubor": patch
+---
+
+Fix the bug when there is no text field And Modify the format of manualCreatedTranscriptsContents

--- a/src/fetchers.ts
+++ b/src/fetchers.ts
@@ -15,16 +15,16 @@ export async function getTranscripts(input: string): Promise<TranscriptResponse>
     const captionJson = extractHtml(htmlContent);
     const transcriptList = buildTranscript(captionJson, videoId);
 
-    const manuallyCreatedTranscriptsContents: { [languageCode: string]: TranscriptObject[] }[] = [];
+    const manuallyCreatedTranscriptsContents: { [languageCode: string]: TranscriptObject[] } = {};
     const generatedTranscriptsContents: { [languageCode: string]: TranscriptObject[] } = {};
-    for (const transcriptObject of transcriptList.manuallyCreatedTranscripts) {
-      for (const languageCode in transcriptObject) {
-        const transcript = transcriptObject[languageCode];
-        const baseUrl = transcript.baseUrl;
-        const responseData = await transcriptContestFetcher(baseUrl);
-        const result: TranscriptObject[] = transcriptParser(responseData);
-        manuallyCreatedTranscriptsContents.push({ [languageCode]: result });
-      }
+    if (Object.keys(transcriptList.manuallyCreatedTranscripts).length > 0) {
+        for (const lang of Object.keys(transcriptList.manuallyCreatedTranscripts)) {
+            const manuallyTranscript = transcriptList.manuallyCreatedTranscripts[lang];
+            const baseUrl = manuallyTranscript.baseUrl;
+            const responseData = await transcriptContestFetcher(baseUrl);
+            const result: TranscriptObject[] = transcriptParser(responseData);
+            manuallyCreatedTranscriptsContents[lang] = result
+        }
     }
     if (Object.keys(transcriptList.generatedTranscripts).length > 0) {
       // there are only one generatedTranscripts

--- a/src/models.ts
+++ b/src/models.ts
@@ -3,13 +3,13 @@
 export class TranscriptResponse {
   public videoId: string;
   public status: string;
-  public manuallyCreatedTranscriptsContents: { [languageCode: string]: TranscriptObject[] }[];
+  public manuallyCreatedTranscriptsContents: { [languageCode: string]: TranscriptObject[] };
   public generatedTranscriptsContents: { [languageCode: string]: TranscriptObject[] };
 
   constructor(
     videoId: string,
     status: string,
-    manuallyCreatedTranscriptsContents: { [languageCode: string]: TranscriptObject[] }[],
+    manuallyCreatedTranscriptsContents: { [languageCode: string]: TranscriptObject[] },
     generatedTranscriptsContents: { [languageCode: string]: TranscriptObject[] },
   ) {
     this.videoId = videoId;
@@ -46,12 +46,12 @@ export class Transcript {
 
 export class TranscriptList {
   public videoId: string;
-  public manuallyCreatedTranscripts: { [languageCode: string]: Transcript }[];
+  public manuallyCreatedTranscripts: { [languageCode: string]: Transcript };
   public generatedTranscripts: { [languageCode: string]: Transcript };
 
   constructor(
     videoId: string,
-    manuallyCreatedTranscripts: { [languageCode: string]: Transcript }[],
+    manuallyCreatedTranscripts: { [languageCode: string]: Transcript },
     generatedTranscripts: { [languageCode: string]: Transcript },
   ) {
     this.videoId = videoId;

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -14,7 +14,7 @@ export function transcriptParser(input: string): TranscriptObject[] {
 
   return textArray.map((textData: any) => ({
     // Use the regular expression /\n/g and /\t/g to replace \n and \t with the empty string ''
-    text: unescape(textData._text.replace(/\n/g, '').replace(/\t/g, '')),
+    text: textData._text ? unescape(textData._text.replace(/\n/g, '').replace(/\t/g, '')) : '',
     // If the start or dur is null or undefined use 0.0 as the default value
     start: parseFloat(textData._attributes.start) || 0.0,
     dur: parseFloat(textData._attributes.dur) || 0.0,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,7 +40,7 @@ export function buildTranscript(captionsJson: any, videoId: string): TranscriptL
     }),
   );
 
-  const manuallyCreatedTranscripts: { [languageCode: string]: Transcript }[] = [];
+  const manuallyCreatedTranscripts: { [languageCode: string]: Transcript } = {};
   const generatedTranscripts: { [languageCode: string]: Transcript } = {};
   const transcriptObject: { [languageCode: string]: Transcript } = {};
 
@@ -56,8 +56,7 @@ export function buildTranscript(captionsJson: any, videoId: string): TranscriptL
     if (caption.kind === 'asr') {
       generatedTranscripts[caption.languageCode] = transcriptDict;
     } else {
-      transcriptObject[caption.languageCode] = transcriptDict;
-      manuallyCreatedTranscripts.push(transcriptObject);
+      manuallyCreatedTranscripts[caption.languageCode] = transcriptDict
     }
   }
 


### PR DESCRIPTION
### Description
1. Since some subtitles will lack the text field, this field is verified.
2. Modify the format of manualCreatedTranscriptsContents
### Changes
- Add verification of the text field in the parser step. If text is undefined, set it to ''
- Modify the format of manualCreatedTranscriptsContents