### PR TITLE
Hammr clear error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tubor",
-  "version": "0.0.9",
+  "version": "0.0.12",
   "description": "Fetch YouTube video transcripts",
   "repository": {
     "type": "git",

--- a/src/tubor.error.ts
+++ b/src/tubor.error.ts
@@ -3,6 +3,7 @@ export const ExceptionCode = {
   REQUEST_ERROR: 'TURBO.BASIC.0002',
   MATCH_ERROR: 'TURBO.BASIC.0003',
   EXTRACT_ERROR: 'TURBO.BASIC.0004',
+  CAN_NOT_FIND_TRANSCRIPT: 'TURBO.BASIC.0005',
   DEFAULT_ERROR: 'TURBO.BASIC.9999',
 } as const;
 
@@ -18,6 +19,7 @@ export class TuborBasicError extends Error {
       ['TURBO.BASIC.0002', 'Request error'],
       ['TURBO.BASIC.0003', 'Video not found'],
       ['TURBO.BASIC.0004', 'Extract html error'],
+      ['TURBO.BASIC.0005', 'This youtube video does not have transcript'],
       ['TURBO.BASIC.9999', 'Default tuborBasicError'],
     ]);
     this.detail = detail;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,8 +9,8 @@ export function extractHtml(html: string): any {
   const splittedHtml = html.split('"captions":');
   if (splittedHtml.length <= 1) {
     throw new ExtractHtmlError(
-      ExceptionCode.EXTRACT_ERROR,
-      "Invalid HTML format: 'captions' section not found.",
+      ExceptionCode.CAN_NOT_FIND_TRANSCRIPT,
+      "Invalid HTML format: 'captions' section not found.This youtube video does not have corresponding transcript",
     );
   }
   const captionJson = JSON.parse(


### PR DESCRIPTION
### Description
Add clear error message for videos without transcript.
### Changes
- When this is no '"captions":' in html, add a clear error to clarify that this video does not have a transcript.